### PR TITLE
Add mock API

### DIFF
--- a/port_eye/mock_nmap.py
+++ b/port_eye/mock_nmap.py
@@ -129,6 +129,15 @@ class MockPortScanner():
             
             return ports_result[port]
     
+    def get_hostname(self, host):
+        """Return the hostname for an ip."""
+        hostnames = {
+            '127.0.0.1': 'localhost',
+            '92.222.10.88': 'valinor.aurelienhugues.com',
+            '::1': 'localhost'
+        }
+        return hostnames[host]
+    
     def build_result_ipv4(self, host, ports, skip_ping=False):
         """Build the returned dict for ipv4 hosts
 
@@ -143,11 +152,12 @@ class MockPortScanner():
         """
         global_infos = self.build_global_test_info(host, skip_ping)
         tcp_dict = {}
+        hostname = self.get_hostname(host)
         for port in ports:
             tcp_dict[port] = self.build_tcp_result(port, skip_ping)
 
         host_dict = {
-                    'hostnames': [{'name': 'localhost', 'type': 'PTR'}],
+                    'hostnames': [{'name': hostname, 'type': 'PTR'}],
                     'addresses': {'ipv4': host},
                     'status': {'state': 'up', 'reason': 'conn-refused'},
                     'tcp': tcp_dict
@@ -178,6 +188,18 @@ class MockPortScanner():
         }
 
         return result 
+    
+    def scanstats(self):
+        """
+        returns scanstats structure
+        {'uphosts': '3', 'timestr': 'Thu Jun  3 21:45:07 2010', 'downhosts': '253', 'totalhosts': '256', 'elapsed': '5.79'}
+
+        may raise AssertionError exception if called before scanning
+        """
+        assert 'nmap' in self._scan_result, 'Do a scan before trying to get result !'
+        assert 'scanstats' in self._scan_result['nmap'], 'Do a scan before trying to get result !'
+
+        return self._scan_result['nmap']['scanstats']        
 
     def scan(self, hosts="127.0.0.1", ports=None, arguments="-sV", sudo=False):
         """Scan given hosts

--- a/port_eye/mock_nmap.py
+++ b/port_eye/mock_nmap.py
@@ -133,12 +133,13 @@ class MockPortScanner():
         """Return the hostname for an ip."""
         hostnames = {
             '127.0.0.1': 'localhost',
-            '92.222.10.88': 'valinor.aurelienhugues.com',
-            '::1': 'localhost'
+            '92.222.10.88': 'example.com',
+            '::1': 'localhost',
+            '2a01:e0a:129:5ed0:211:32ff:fe2d:68da': 'acme.me'
         }
         return hostnames[host]
     
-    def build_result_ipv4(self, host, ports, skip_ping=False):
+    def build_result_ipv4(self, host, ports, skip_ping=False, ipv='ipv4'):
         """Build the returned dict for ipv4 hosts
 
         If the skip_ping argument is set to True, results are sure to be 
@@ -147,6 +148,7 @@ class MockPortScanner():
         :param host: host to scan
         :param ports: list of ports to scan (must be in range (22, 80, 443))
         :param skip_ping: bool for skipping ping (default to False)
+        :param ipv: str indicating qui IPversion is used (default ipv4)
 
         :returns: scan_result as dictionnary
         """
@@ -158,7 +160,7 @@ class MockPortScanner():
 
         host_dict = {
                     'hostnames': [{'name': hostname, 'type': 'PTR'}],
-                    'addresses': {'ipv4': host},
+                    'addresses': {ipv: host},
                     'status': {'state': 'up', 'reason': 'conn-refused'},
                     'tcp': tcp_dict
         }
@@ -225,16 +227,16 @@ class MockPortScanner():
             assert type(arguments) is str, 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
 
         skip_ping = "-Pn" in arguments
-        is_ipv6 = "6" in arguments
+        ipv = 'ipv6' if "6" in arguments else 'ipv4'
+
 
         ports = [22] if hosts == '127.0.0.1' else [22, 80, 443]
-        if is_ipv6:
-            return None
         
         if self.reachable(hosts, skip_ping):
-            result = self.build_result_ipv4(hosts, ports, skip_ping)
+            result = self.build_result_ipv4(hosts, ports, skip_ping, ipv=ipv)
         else:
             result = self.build_result_unreachable(hosts, skip_ping)
+
         self._scan_result = result
         return result
 

--- a/port_eye/mock_nmap.py
+++ b/port_eye/mock_nmap.py
@@ -1,0 +1,155 @@
+"""Mock nmap scanner to be used for unit testing in the CI process."""
+
+import sys
+
+class MockPortScanner():
+    """MockPortScanner allows to use a mock version of nmap from Python."""
+
+    def __init__(self):
+        """Initialize MockPortScanner module."""
+        pass 
+
+    def build_global_test_info(self, host, skip_ping=False, ipv6=False):
+        """Build the command_line and scanstats parts of the response.
+
+        :param host: scanned host
+        :param skip_ping: bool for skipping ping (default to False)
+        :param ipv6: bool for creating request for ipv6 host (default to False)
+
+        :returns global_result as dictionnary
+        """
+        ip_argument = '6' if ipv6 else ''
+        skip_argument = 'Pn' if skip_ping else 'sV'
+        command_line = 'nmap -oX -{} -{} {}'.format(
+            ip_argument,
+            skip_argument,
+            host
+        )
+        elapsed = '10.7' if skip_ping else '4.2'
+        return {
+            'command_line': command_line,
+            'scanstats': {
+                'timestr': 'Sun Sep  8 10:21:46 2019',
+                'elapsed': elapsed,
+                'uphosts': '1',
+                'downhosts': '0',
+                'totalhosts': '1',
+            }
+        }
+    
+    def build_tcp_result(self, port, skip_ping=False):
+        """Build the result for a port.
+
+        :param port: scanned port
+        :param skip_ping: bool for skipping ping (default to False)
+
+        :returns port_result as dictionnary
+        """
+
+        if port not in [22, 80, 443]:
+            raise KeyError('Port not in range (22, 80, 443)')
+
+        else:
+            additionnal_infos = ['product', 'version', 'extrainfo', 'cpe']
+            ports_result = {
+                22: {
+                    'state': 'open',
+                    'reason': 'syn-ack',
+                    'name': 'ssh',
+                    'product': 'OpenSSH',
+                    'version': '7.6p1 Ubuntu 4ubuntu0.3',
+                    'extrainfo': 'Ubuntu Linux; protocol 2.0',
+                    'conf': '10',
+                    'cpe': 'cpe:/o:linux:linux_kernel'
+                },
+                80: {
+                    'state': 'open',
+                    'reason': 'syn-ack',
+                    'name': 'http',
+                    'product': 'nginx',
+                    'version': '',
+                    'extrainfo': '',
+                    'conf': '10',
+                    'cpe': 'cpe:/a:igor_sysoev:nginx'
+                },
+                443: {
+                    'state': 'open',
+                    'reason': 'syn-ack',
+                    'name': 'http',
+                    'product': 'nginx',
+                    'version': '',
+                    'extrainfo': '',
+                    'conf': '10',
+                    'cpe': 'cpe:/a:igor_sysoev:nginx'
+                }
+            }
+
+            # Remove additionnal info if ping is skipped
+            if skip_ping:
+                for info in additionnal_infos:
+                    ports_result[port][info] = ''
+                ports_result[port]['conf'] = '3'
+            
+            return ports_result[port]
+    
+    def build_result_ipv4(self, ports, skip_ping=False):
+        """Build the returned dict for ipv4 hosts
+
+        If the skip_ping argument is set to True, results are sure to be 
+        computed, but the result will have less information.
+
+        :param ports: list of ports to scan (must be in range (22, 80, 443))
+        :param skip_ping: bool for skipping ping (default to False)
+
+        :returns: scan_result as dictionnary
+        """
+        global_infos = self.build_global_test_info('127.0.0.1', skip_ping)
+        tcp_dict = {}
+        for port in ports:
+            tcp_dict[port] = self.build_tcp_result(port, skip_ping)
+
+        result = {
+            'nmap': global_infos,
+            'scan': {
+                '127.0.0.1': {
+                    'hostnames': [{'name': 'localhost', 'type': 'PTR'}],
+                    'addresses': {'ipv4': '127.0.0.1'},
+                    'status': {'state': 'up', 'reason': 'conn-refused'},
+                    'tcp': tcp_dict
+                }
+            }
+        }
+        return result
+
+    def scan(self, hosts="127.0.0.1", ports=None, arguments="-sV", sudo=False):
+        """Scan given hosts
+
+        Results are returned as a dictionnary that will always return the 
+        same results.
+
+        :param hosts: string for hosts as nmap use it 'scanme.nmap.org' or 
+            '198.116.0-255.1-127' or '216.163.128.20/20'
+        :param ports: string for ports as nmap use it '22,53,110,143-4564'
+        :param arguments: string of arguments for nmap '-sU -sX -sC'
+        :param sudo: launch nmap with sudo if True (this has no effect here)
+
+        :returns: scan_result as dictionnary
+        """
+        if sys.version_info[0]==2:
+            assert type(hosts) in (str, unicode), 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))  # noqa
+            assert type(ports) in (str, unicode, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))  # noqa
+            assert type(arguments) in (str, unicode), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
+        else:
+            assert type(hosts) is str, 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))  # noqa
+            assert type(ports) in (str, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))  # noqa
+            assert type(arguments) is str, 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
+
+        skip_ping = "-Pn" in arguments
+        is_ipv6 = "6" in arguments
+
+        ports = [22] if hosts == '127.0.0.1' else [22, 80, 443]
+        if is_ipv6:
+            return None
+        
+        return self.build_result_ipv4(ports, skip_ping)
+

--- a/port_eye/mock_nmap.py
+++ b/port_eye/mock_nmap.py
@@ -12,7 +12,7 @@ class MockPortScanner():
     
     def __getitem__(self, host):
         """Return a host detail."""
-        if sys.version_info[0]==2:
+        if sys.version_info[0]==2: # pragma: no cover
             assert type(host) in (str, unicode), 'Wrong type for [host], should be a string [was {0}]'.format(type(host))
         else:
             assert type(host) is str, 'Wrong type for [host], should be a string [was {0}]'.format(type(host))
@@ -135,7 +135,8 @@ class MockPortScanner():
             '127.0.0.1': 'localhost',
             '92.222.10.88': 'example.com',
             '::1': 'localhost',
-            '2a01:e0a:129:5ed0:211:32ff:fe2d:68da': 'acme.me'
+            '2a01:e0a:129:5ed0:211:32ff:fe2d:68da': 'acme.me',
+            "82.64.28.100": 'acne.bad'
         }
         return hostnames[host]
     
@@ -217,7 +218,7 @@ class MockPortScanner():
 
         :returns: scan_result as dictionnary
         """
-        if sys.version_info[0]==2:
+        if sys.version_info[0]==2: # pragma: no cover
             assert type(hosts) in (str, unicode), 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))  # noqa
             assert type(ports) in (str, unicode, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))  # noqa
             assert type(arguments) in (str, unicode), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
@@ -226,7 +227,7 @@ class MockPortScanner():
             assert type(ports) in (str, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))  # noqa
             assert type(arguments) is str, 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
 
-        skip_ping = "-Pn" in arguments
+        skip_ping = "Pn" in arguments
         ipv = 'ipv6' if "6" in arguments else 'ipv4'
 
 

--- a/tests/test_mock_nmap.py
+++ b/tests/test_mock_nmap.py
@@ -1,0 +1,42 @@
+"""Test the mock nmap API."""
+
+import pytest
+from port_eye.mock_nmap import MockPortScanner
+
+def test_ping_blocked():
+    """Test non-detection of hosts when ping blocked."""
+
+    host = u"82.64.28.100"
+    scanner = MockPortScanner()
+    assert scanner.reachable(host) is False
+
+
+def test_ping_skipped():
+    """Test detection of hosts when ping skipped."""
+
+    host = u"82.64.28.100"
+    scanner = MockPortScanner()
+    assert scanner.reachable(host, skip_ping=True) is True
+
+
+def test_port_range():
+    """Test that only allowed ports can be used."""
+
+    host = 'localhost'
+    scanner = MockPortScanner()
+    with pytest.raises(KeyError):
+        scanner.build_tcp_result(42)
+
+
+def test_additionnal_info_removal():
+    """Test that additionnal info are removed when skipping ping."""
+
+    host = 'localhost'
+    scanner = MockPortScanner()
+
+    result = scanner.build_tcp_result(22, True)
+    assert result['product'] == ''
+    assert result['version'] == ''
+    assert result['extrainfo'] == ''
+    assert result['cpe'] == ''
+    assert result['conf'] == '3'

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -68,13 +68,13 @@ def test_reachable():
         scanner = Scanner(host, mock=True)
         assert scanner.is_reachable() is False
 
-# This test is disabled because of lack of support from TravisCI
-# def test_reachable_ipv6():
-    # """Check the detection of reachable hosts while IPV6."""
-    # reachable_host = ipaddress.ip_address(
-        # u"2a01:e0a:129:5ed0:211:32ff:fea8:97e")
-    # scanner = Scanner(reachable_host, True)
-    # assert scanner.is_reachable() is True
+
+def test_reachable_ipv6():
+    """Check the detection of reachable hosts while IPV6."""
+    reachable_host = ipaddress.ip_address(
+        u'2a01:e0a:129:5ed0:211:32ff:fe2d:68da')
+    scanner = Scanner(reachable_host, True, mock=True)
+    assert scanner.is_reachable() is True
 
 
 def test_protocol_verification():
@@ -131,7 +131,7 @@ def test_host_scanning():
     report = scanner.extract_host_report()
     assert report.__class__ == HostReport
 
-    assert report.hostname == 'valinor.aurelienhugues.com'
+    assert report.hostname == 'example.com'
     assert report.ip == '92.222.10.88'
     assert report.mac == ''
     assert report.state == 'up'
@@ -145,21 +145,21 @@ def test_host_scanning():
     for expected_port in expected_ports:
         assert expected_port in port_numbers
 
-# This test is disabled because of lack of support from TravisCI
-# def test_host_scanning_ipv6():
-#     """Test the report extraction from an IPV6 host."""
 
-#     host = ipaddress.ip_address(u"::1")
-#     scanner = Scanner(host, True)
-#     scanner.perform_scan()
+def test_host_scanning_ipv6():
+    """Test the report extraction from an IPV6 host."""
 
-#     report = scanner.extract_host_report()
-#     assert report.__class__ == HostReport
+    host = ipaddress.ip_address(u"::1")
+    scanner = Scanner(host, True, mock=True)
+    scanner.perform_scan()
 
-#     assert report.hostname == 'localhost'
-#     assert report.ip == '::1'
-#     assert report.state == 'up'
-#     assert len(report.ports) >= 0
+    report = scanner.extract_host_report()
+    assert report.__class__ == HostReport
+
+    assert report.hostname == 'localhost'
+    assert report.ip == '::1'
+    assert report.state == 'up'
+    assert len(report.ports) >= 0
 
 
 def test_scanner_handler_creation():

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -27,7 +27,7 @@ def test_wrong_format():
 def test_correct_format():
     """Test that the create of a scanner works."""
     host = ipaddress.ip_address(u"192.168.0.1")
-    scanner = Scanner(host)
+    scanner = Scanner(host, mock=True)
     assert scanner.raw_host == host
     assert scanner.host == u"192.168.0.1"
 
@@ -39,10 +39,10 @@ def test_detection_private_host():
     private_ipv6 = ipaddress.ip_address(u"fe80::a00:27ff:fe8f:ec03")
     public_ipv6 = ipaddress.ip_address(u"2a00:1450:4007:80a::200e")
 
-    scanner_private_ipv4 = Scanner(private_host)
-    scanner_public_ipv4 = Scanner(public_host)
-    scanner_private_ipv6 = Scanner(private_ipv6)
-    scanner_public_ipv6 = Scanner(public_ipv6)
+    scanner_private_ipv4 = Scanner(private_host, mock=True)
+    scanner_public_ipv4 = Scanner(public_host, mock=True)
+    scanner_private_ipv6 = Scanner(private_ipv6, mock=True)
+    scanner_public_ipv6 = Scanner(public_ipv6, mock=True)
 
     assert scanner_private_ipv4.is_local() is True
     assert scanner_public_ipv4.is_local() is False
@@ -61,11 +61,11 @@ def test_reachable():
     ]
 
     for host in reachable_hosts:
-        scanner = Scanner(host)
+        scanner = Scanner(host, mock=True)
         assert scanner.is_reachable() is True
 
     for host in unreachable_hosts:
-        scanner = Scanner(host)
+        scanner = Scanner(host, mock=True)
         assert scanner.is_reachable() is False
 
 # This test is disabled because of lack of support from TravisCI
@@ -81,7 +81,7 @@ def test_protocol_verification():
     """Test that only acceptable protocols types are accepted."""
 
     host = ipaddress.ip_address(u'127.0.0.1')
-    scanner = Scanner(host)
+    scanner = Scanner(host, mock=True)
 
     scanner.perform_scan()
 
@@ -103,7 +103,7 @@ def test_ports_scanning():
     Test is ran on a machine with at least ports 22/80/443 opened.
     """
     host = ipaddress.ip_address(u'92.222.10.88')
-    scanner = Scanner(host)
+    scanner = Scanner(host, mock=True)
 
     assert scanner.is_local() is False
     assert scanner.is_reachable() is True
@@ -125,7 +125,7 @@ def test_host_scanning():
     """Test the report extraction from a complete host."""
 
     host = ipaddress.ip_address(u'92.222.10.88')
-    scanner = Scanner(host)
+    scanner = Scanner(host, mock=True)
     scanner.perform_scan()
 
     report = scanner.extract_host_report()
@@ -175,7 +175,8 @@ def test_scanner_handler_creation():
         ipaddress.ip_network(u"192.168.0.1/32")
     ]
 
-    scanner_handler = ScannerHandler(ipv4_hosts, ipv6_hosts, cidr_blocks)
+    scanner_handler = ScannerHandler(
+        ipv4_hosts, ipv6_hosts, cidr_blocks, mock=True)
 
     assert len(scanner_handler.ipv4_hosts) == 2
     assert len(scanner_handler.ipv6_hosts) == 1
@@ -199,7 +200,7 @@ def test_scan_handling():
         ipaddress.ip_address(u"127.0.0.1"),
         ipaddress.ip_address(u"192.0.2.1")
     ]
-    scanner_handler = ScannerHandler(ipv4_hosts, [], [])
+    scanner_handler = ScannerHandler(ipv4_hosts, [], [], mock=True)
     hosts_queue = Queue()
 
     scanner_handler.run_scan(scanner_handler.scanners[0], hosts_queue)
@@ -217,7 +218,7 @@ def test_running_scans():
         # ipaddress.ip_address(u"::1")
     # ]
 
-    scanner_handler = ScannerHandler(ipv4_hosts, [], [])
+    scanner_handler = ScannerHandler(ipv4_hosts, [], [], mock=True)
     report = scanner_handler.run_scans()
 
     assert report.__class__ == Report


### PR DESCRIPTION
Add a mock API to replace actual calls to the nmap library during unit tests to increase speed. 

Also add support for IPV6 that was removed due to lack of support on TravisCI